### PR TITLE
Allow (srfi 1) to fill in for (scheme list) when latter unavailable.

### DIFF
--- a/slib/rev2-procedures.sld
+++ b/slib/rev2-procedures.sld
@@ -32,8 +32,12 @@
           =?
           >?
           >=?)
-  (import (scheme base)
-          (only (scheme list) last-pair))
+  (import (scheme base))
+  (cond-expand
+    ((library (scheme list))
+     (import (only (scheme list) last-pair)))
+    (else
+     (import (only (srfi 1) last-pair))))
 
   (begin
 

--- a/slib/xml-parse.sld
+++ b/slib/xml-parse.sld
@@ -72,8 +72,12 @@
           (scheme cxr)  
           (slib common)
           (slib rev2-procedures)
-          (slib string-search)
-          (scheme list))
+          (slib string-search))
+  (cond-expand
+    ((library (scheme list))
+     (import (scheme list)))
+    (else
+     (import (srfi 1))))
 
   (begin
     ;;@subsection String Glue

--- a/srfis/kawa/srfi/27.sld
+++ b/srfis/kawa/srfi/27.sld
@@ -36,7 +36,7 @@
 
     ;; Uses BigInteger to permit arbitrarily large n
     (define (random-integer-from-source source n)
-      (if (<= n MAX-LONG)
+      (if (<= n MAX-INTEGER)
         ((as Random source):nextInt n)
         (let* ((input (BigInteger (number->string n)))
                (bits (input:bitLength)))


### PR DESCRIPTION
Add a couple of cond-expands to allow (srfi 1) to fill in for (scheme
list).  This seems to be currently required in order to get
(slib xml-parse) working with Kawa. There are other places that could
use a simliar change, but I am holding off for now in case I'm
overlooking something.